### PR TITLE
Remove dependency on System.Locale

### DIFF
--- a/library/API/IB/Request.hs
+++ b/library/API/IB/Request.hs
@@ -13,7 +13,6 @@ import           Data.Monoid                        hiding (All, Product)
 import           Data.String
 import           Data.Time
 import           Prelude                            hiding (takeWhile)
-import           System.Locale
 
 import           API.IB.Constant
 import           API.IB.Data


### PR DESCRIPTION
Resolve conflicting export of `defaultTimeLocale`, which is exported from both `System.Locale` and `Data.Time` by now.